### PR TITLE
録画IDではなくファイルIDを使用するよう修正

### DIFF
--- a/client/video_list.tsx
+++ b/client/video_list.tsx
@@ -19,8 +19,9 @@ async function fetchChannels(): Promise<MirakChannel[]> {
 };
 
 function Record({ record }: { record: EPGRecordedItem }) {
+    const videoId = record.videoFiles?.filter(file => file.type == "ts")[0].id;
     return (
-        <a href={`/videos/${record.id}`}>
+        <a href={`/videos/${videoId}`}>
             {record.name.length === 0 ? "番組名なし" : record.name} {new Date(record.startAt).toLocaleString()}
         </a>
     );


### PR DESCRIPTION
EPGStationの録画番組を視聴する際、パラメータに`VideoFileId`ではなく`RecordedId`を渡していた部分を修正しました。
※エンコードした事があるなど、一致しない場合がありました