### PR TITLE
TS2300 (Duplicate identifier) コンパイルエラーを修正

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -224,16 +224,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*":
-  version "17.0.40"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.40.tgz#dc010cee6254d5239a138083f3799a16638e6bad"
-  integrity sha512-UrXhD/JyLH+W70nNSufXqMZNuUD2cXHu6UjCllC6pmOQgBX4SGXOH8fjRka0O0Ee0HrFxapDD8Bwn81Kmiz6jQ==
-  dependencies:
-    "@types/prop-types" "*"
-    "@types/scheduler" "*"
-    csstype "^3.0.2"
-
-"@types/react@^18.0.18":
+"@types/react@*", "@types/react@^18.0.18":
   version "18.0.18"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.18.tgz#9f16f33d57bc5d9dca848d12c3572110ff9429ac"
   integrity sha512-6hI08umYs6NaiHFEEGioXnxJ+oEhY3eRz8VCUaudZmGdtvPviCJB8mgaMxaDWAdPSYd4eFavrPk2QIolwbLYrg==


### PR DESCRIPTION
おそらく d5ce4a1d9dfca02c8b09ced289bfa62506af62de 以降だと思いますが、"@types/react"が"@types/react-dom"から依存するものと重複してlockされてしまっているため
```
.node_modules/@types/react/index.d.ts:3135:14 - error TS2300: Duplicate identifier 'LibraryManagedAttributes'.
```
みたいなエラーでコンパイルできません。もしかするとnodeやyarnのバージョンによるのかもしれませんが、少なくとも node v16.19.0 と yarn 1.22.19 の組み合わせではエラーです。
プルリクは最小修正にしましたがyarn.lockをたんに作り直しても解決すると思います。