### PR TITLE
AIFFが中間ノードをすっとばして再生されるのを修正

### DIFF
--- a/client/arib_aiff.ts
+++ b/client/arib_aiff.ts
@@ -105,7 +105,7 @@ export function playAIFF(destination: AudioNode, aiff: Buffer): AudioBufferSourc
     buffer.copyToChannel(soundDataF32, 0);
     const source = destination.context.createBufferSource();
     source.buffer = buffer;
-    source.connect(destination.context.destination);
+    source.connect(destination);
     source.start(0);
     return source;
 }


### PR DESCRIPTION
受信機の音量をデータ放送側にも適用させようとした時に、内蔵音はちゃんと音量が反映されるのにAIFF経由だけ反映されなかった
