### PR TITLE
browser.quitDocumentを呼び出せるようにして、リンク状態でもエラーにならいようにする

### DIFF
--- a/client/browser.ts
+++ b/client/browser.ts
@@ -1076,6 +1076,12 @@ export class BrowserAPI {
             this.interpreter.destroyStack();
             throw new Error("unreachable!!");
         },
+        quitDocument: (): number => {
+            console.log("%cquitDocument", "font-size: 4em");
+            this.content.quitDocument();
+            this.interpreter.destroyStack();
+            throw new Error("unreachable!!");
+        },
         reloadActiveDocument: (): number => {
             console.log("reloadActiveDocument");
             return this.browser.launchDocument(this.browser.getActiveDocument()!);

--- a/client/content.ts
+++ b/client/content.ts
@@ -885,7 +885,7 @@ export class Content {
     }
 
     private async launchStartup(): Promise<boolean> {
-        const module = `/${this.resources.startupComponentId.toString(16).padStart(2, "0")}/${this.resources.startupModuleId.toString(16).padStart(4, "0")}`;
+        const module = `arib-dc://-1.-1.-1/${this.resources.startupComponentId.toString(16).padStart(2, "0")}/${this.resources.startupModuleId.toString(16).padStart(4, "0")}`;
         await this.resources.fetchResourceAsync(module);
         if (this.resources.fetchLockedResource(module + "/startup.bml")) {
             await this.launchDocumentAsync(module + "/startup.bml");

--- a/client/interpreter/es2_binding.ts
+++ b/client/interpreter/es2_binding.ts
@@ -399,6 +399,13 @@ export function defineBrowserBinding(context: Context, resources: Resources, bro
         return r;
     }
 
+    function* quitDocument() {
+        browserLog("quitDocument");
+        content.quitDocument();
+        yield LAUNCH_DOCUMENT_CALLED;
+        return NaN;
+    }
+
     function* X_DPA_launchDocWithLink(documentName: string, transitionStyle: string | undefined) {
         console.log("%X_DPA_launchDocWithLink", "font-size: 4em", documentName);
         if (resources.profile !== Profile.TrProfileC) {
@@ -557,6 +564,12 @@ export function defineBrowserBinding(context: Context, resources: Resources, bro
             const transitionStyle = args[1] === undefined ? args[1] : yield* toString(ctx, args[1], caller);
             return yield* launchDocument(documentName, transitionStyle);
         }, 1, "launchDocument"),
+    });
+    browser.properties.set("quitDocument", {
+        ...desc,
+        value: newNativeFunction(context.realm.intrinsics.FunctionPrototype, function* browser$quitDocument() {
+            return yield* quitDocument();
+        }, 0, "quitDocument"),
     });
     browser.properties.set("reloadActiveDocument", {
         ...desc,


### PR DESCRIPTION
NHK総合・東京でNHKプラスの説明ページを表示している時に、dボタン押下でドキュメントを閉じれなかった。以下のエラーが開発者コンソールに出ていた。

```
[Error] unhandled error – 85 (3)
{from: "http://bml.nhk.jp/startup.bml", to: "http://bml.nhk.jp/bml-nhkone/nhkone.bml"}
{from: "http://bml.nhk.jp/startup.bml", to: "http://bml.nhk.jp/bml-nhkone/nhkone.bml"}
Error: failed to call undefined dPress (http://bml.nhk.jp/bml-nhkone/nhkone.bml[1]:542) global (eventHandler:dPress:1) — bml.js:32022
	runScript (bml.js:2:477756)
	runEventHandler (bml.js:2:478189)
	executeEventHandler (bml.js:2:340120)
	（anonymous関数） (bml.js:2:337605)
	processEventQueue (bml.js:2:341506)
	dispatchDataButtonPressedEvent (bml.js:2:337675)
	processKeyDown (bml.js:2:307786)
	onNativeMessage (bml.js:2:836731)
	グローバルコード (スクリプト要素4,352:1)
```

browser.quitDocumentは実装されているけど呼び出せる状態じゃなかったので、呼び出せるようにした。

また、`launchStartup` が相対URIでstartupのドキュメントを呼び出しているが、これはリンク状態だと通信側のURIで解決されてエラーになるので、仕様書にあるとおりデータカルーセル側を指定するようにした

これで当該ページでもdボタン押下でドキュメントを正しく閉じれるようになった
